### PR TITLE
Finishes `flagRequest` Mutation

### DIFF
--- a/packages/apollos-data-prayer/src/prayer-requests/schema.js
+++ b/packages/apollos-data-prayer/src/prayer-requests/schema.js
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 
 const prayerRequestSchema = gql`
   extend type Query {
-    getPublicPrayerRequests: [PrayerRequest]
+    getPublicPrayerRequests: [PrayerRequest] @cacheControl(maxAge: 0)
     getPublicPrayerRequestsByCampus(campusId: Int!): [PrayerRequest]
     getCurrentPersonPrayerRequests: [PrayerRequest] @cacheControl(maxAge: 0)
     getPrayerRequestsByGroups: [PrayerRequest]

--- a/packages/newspringchurchapp/src/prayer/ChurchPrayer/getPublicPrayerRequests.js
+++ b/packages/newspringchurchapp/src/prayer/ChurchPrayer/getPublicPrayerRequests.js
@@ -1,13 +1,14 @@
 import gql from 'graphql-tag';
 
 export default gql`
-  query {
+  query getCampusPrayerRequests {
     getPublicPrayerRequests {
       id
       firstName
       lastName
       isAnonymous
       text
+      flagCount
     }
   }
 `;

--- a/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCardConnected.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCardConnected.js
@@ -7,7 +7,10 @@ import PrayerCard from './PrayerCard';
 
 // eslint-disable-next-line react/display-name
 const PrayerCardConnected = memo(({ id, ...props }) => (
-  <Mutation mutation={flagPrayerRequest}>
+  <Mutation
+    mutation={flagPrayerRequest}
+    update={async(cache, { data: { flagRequest } })}
+  >
     {(handlePress) => (
       <PrayerCard
         flagRequest={async () => {

--- a/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCardConnected.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCardConnected.js
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import { Mutation } from 'react-apollo';
 import PropTypes from 'prop-types';
 
-import getCampusPrayerRequests from '../ChurchPrayer';
+import getCampusPrayerRequests from '../ChurchPrayer/getPublicPrayerRequests';
 import flagPrayerRequest from './flagPrayerRequest';
 import PrayerCard from './PrayerCard';
 
@@ -14,20 +14,19 @@ const PrayerCardConnected = memo(({ id, ...props }) => (
       const currentPrayerList = cache.readQuery({
         query: getCampusPrayerRequests,
       });
-      console.warn('after readQuery');
       const flagIndex = currentPrayerList.getPublicPrayerRequests.findIndex(
         (prayer) => prayer.id === flagRequest.id
       );
       const incrementFlag = () => {
-        currentPrayerList.getPublicPrayerRequests.flagCount += 1;
+        currentPrayerList.getPublicPrayerRequests[flagIndex].flagCount += 1;
       };
       const updatedPrayerList = () => {
         currentPrayerList.getPublicPrayerRequests.forEach((prayer) =>
-          prayer.id === flagIndex ? incrementFlag(prayer) : prayer
+          prayer.id === flagRequest.id ? incrementFlag(prayer) : prayer
         );
         return currentPrayerList.getPublicPrayerRequests;
       };
-      console.warn('THIS IS WORKING', updatedPrayerList);
+      updatedPrayerList(currentPrayerList.getPublicPrayerRequests);
       await cache.writeQuery({
         query: getCampusPrayerRequests,
         data: { getPublicPrayerRequests: updatedPrayerList },

--- a/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCardConnected.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCardConnected.js
@@ -2,6 +2,7 @@ import React, { memo } from 'react';
 import { Mutation } from 'react-apollo';
 import PropTypes from 'prop-types';
 
+import getCampusPrayerRequests from '../ChurchPrayer';
 import flagPrayerRequest from './flagPrayerRequest';
 import PrayerCard from './PrayerCard';
 
@@ -9,7 +10,29 @@ import PrayerCard from './PrayerCard';
 const PrayerCardConnected = memo(({ id, ...props }) => (
   <Mutation
     mutation={flagPrayerRequest}
-    update={async(cache, { data: { flagRequest } })}
+    update={async (cache, { data: { flagRequest } }) => {
+      const currentPrayerList = cache.readQuery({
+        query: getCampusPrayerRequests,
+      });
+      console.warn('after readQuery');
+      const flagIndex = currentPrayerList.getPublicPrayerRequests.findIndex(
+        (prayer) => prayer.id === flagRequest.id
+      );
+      const incrementFlag = () => {
+        currentPrayerList.getPublicPrayerRequests.flagCount += 1;
+      };
+      const updatedPrayerList = () => {
+        currentPrayerList.getPublicPrayerRequests.forEach((prayer) =>
+          prayer.id === flagIndex ? incrementFlag(prayer) : prayer
+        );
+        return currentPrayerList.getPublicPrayerRequests;
+      };
+      console.warn('THIS IS WORKING', updatedPrayerList);
+      await cache.writeQuery({
+        query: getCampusPrayerRequests,
+        data: { getPublicPrayerRequests: updatedPrayerList },
+      });
+    }}
   >
     {(handlePress) => (
       <PrayerCard

--- a/packages/newspringchurchapp/src/prayer/PrayerCard/__snapshots__/PrayerCard.tests.js.snap
+++ b/packages/newspringchurchapp/src/prayer/PrayerCard/__snapshots__/PrayerCard.tests.js.snap
@@ -424,7 +424,7 @@ exports[`the PrayerCard component renders a prayer card 1`] = `
                     }
                   }
                 >
-                  Start Praying for Bill
+                  Pray
                 </Text>
               </View>
             </View>

--- a/packages/newspringchurchapp/src/prayer/PrayerCard/__snapshots__/PrayerCardConnected.tests.js.snap
+++ b/packages/newspringchurchapp/src/prayer/PrayerCard/__snapshots__/PrayerCardConnected.tests.js.snap
@@ -507,7 +507,7 @@ exports[`the UserPrayerList component renders a list of prayers 1`] = `
                     }
                   }
                 >
-                  Start Praying for undefined
+                  Pray
                 </Text>
               </View>
             </View>


### PR DESCRIPTION
## DESCRIPTION

As a User, when I report a prayer I want the app to dynamically update that prayer's status without making a server call.

### What does this PR do, or why is it needed?

This PR adds the `update` on the `flagRequest` mutation which allows for a dynamic update of the `flagCount` -- currently though, all the logic for filtering reported prayers is handled server-side, so we need to mimic that in the app.

### How do I test this PR?

You will need to run in debug mode. Put a console.log like this:
`updatedPrayerList(currentPrayerList.getPublicPrayerRequests);
console.log(currentPrayerList.getPublicPrayerRequests);`

This will log the array and check the `flagCount` of the prayer that you flagged.

---

> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [DEV-XXX](#url)
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android if applicable
- [ ] Set two relevant reviewers

## REVIEW

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

---

> The purpose of PR Review is to _improve the quality of the software._
