### PR TITLE
Add Anonymous Handling to Prayer Card

### DIFF
--- a/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCard.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCard.js
@@ -50,8 +50,9 @@ const GreyH6 = styled(({ theme }) => ({
   color: theme.colors.text.tertiary,
 }))(H6);
 
-const StyledCardContent = styled(() => ({
+const StyledCardContent = styled(({ theme }) => ({
   alignItems: 'center',
+  marginBottom: theme.sizing.baseUnit,
 }))(CardContent);
 
 const UserHeader = styled(({ theme }) => ({
@@ -86,6 +87,7 @@ class PrayerCard extends PureComponent {
       prayer,
       options,
       navigation,
+      anonymous,
     } = this.props;
 
     // add a cancel button
@@ -114,8 +116,8 @@ class PrayerCard extends PureComponent {
                 this.ActionSheet = sheet;
               }}
               options={buttons.map((option) => option.title)}
-              cancelButtonIndex={buttons.length} // ActionSheet only allows for one destructive button // this will only make the first option listed as destructive turn red
-              destructiveButtonIndex={buttons
+              cancelButtonIndex={buttons.length}
+              destructiveButtonIndex={buttons // ActionSheet only allows for one destructive button // this will only make the first option listed as destructive turn red
                 .map((option) => option.destructive)
                 .indexOf(true)}
               onPress={(index) => handleOnPress(index)}
@@ -125,9 +127,18 @@ class PrayerCard extends PureComponent {
         <StyledCardContent>
           {header ? (
             <UserHeader>
-              <Avatar source={avatarSource} size={avatarSize} />
-              <H3>Pray For {name}</H3>
-              {source ? <GreyH6>{source}</GreyH6> : null}
+              {anonymous ? (
+                <>
+                  <Avatar size={avatarSize} />
+                  <H3>Pray For Request</H3>
+                </>
+              ) : (
+                <>
+                  <Avatar source={avatarSource} size={avatarSize} />
+                  <H3>Pray For {name}</H3>
+                  {source ? <GreyH6>{source}</GreyH6> : null}
+                </>
+              )}
             </UserHeader>
           ) : null}
           <StyledBodyText>{prayer}</StyledBodyText>
@@ -172,6 +183,7 @@ PrayerCard.propTypes = {
   navigation: PropTypes.shape({
     navigate: PropTypes.func,
   }),
+  anonymous: PropTypes.bool,
 };
 
 PrayerCard.defaultProps = {
@@ -182,6 +194,7 @@ PrayerCard.defaultProps = {
   avatarSize: 'small',
   name: 'Request',
   source: 'Web',
+  anonymous: false,
 };
 
 export default PrayerCard;

--- a/packages/newspringchurchapp/src/prayer/PrayerCard/__snapshots__/PrayerCard.tests.js.snap
+++ b/packages/newspringchurchapp/src/prayer/PrayerCard/__snapshots__/PrayerCard.tests.js.snap
@@ -110,6 +110,7 @@ exports[`the PrayerCard component renders a prayer card 1`] = `
           style={
             Object {
               "alignItems": "center",
+              "marginBottom": 16,
               "paddingHorizontal": 16,
               "paddingVertical": 16,
             }

--- a/packages/newspringchurchapp/src/prayer/PrayerPreviewCard/__snapshots__/PrayerPreviewCard.tests.js.snap
+++ b/packages/newspringchurchapp/src/prayer/PrayerPreviewCard/__snapshots__/PrayerPreviewCard.tests.js.snap
@@ -64,6 +64,7 @@ exports[`the PrayerMenuCard component renders a prayer menu card 1`] = `
           style={
             Object {
               "alignItems": "center",
+              "marginBottom": 16,
               "paddingHorizontal": 16,
               "paddingVertical": 16,
             }


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR adds anonymous prayer handling to the prayer card.

### How do I test this PR?
Look at an anonymous prayer that has a header (i.e. a saved prayer) and make sure that the header does not display any identifying information. The avatar should be default, it should say "Pray for Request" and there should be no campus information displayed.

---
> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [n/a] Closes [DEV-XXX](#url)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set two relevant reviewers

## REVIEW

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

---

> The purpose of PR Review is to _improve the quality of the software._
