### PR TITLE
[DEV-3757] Fixes Android `Start Praying` Button

### DIFF
--- a/packages/newspringchurchapp/src/prayer/PrayerPreviewCard/__snapshots__/PrayerPreviewCard.tests.js.snap
+++ b/packages/newspringchurchapp/src/prayer/PrayerPreviewCard/__snapshots__/PrayerPreviewCard.tests.js.snap
@@ -235,8 +235,11 @@ exports[`the PrayerMenuCard component renders a prayer menu card 1`] = `
     <View
       style={
         Object {
-          "paddingHorizontal": 16,
-          "paddingVertical": 16,
+          "bottom": 15,
+          "left": 0,
+          "marginHorizontal": 16,
+          "position": "absolute",
+          "right": 0,
         }
       }
     >
@@ -266,17 +269,13 @@ exports[`the PrayerMenuCard component renders a prayer menu card 1`] = `
               "borderColor": "#6bac43",
               "borderRadius": 48,
               "borderWidth": 2,
-              "bottom": 15,
               "elevation": 2,
               "flexDirection": "row",
               "height": 48,
               "justifyContent": "center",
-              "left": 0,
               "opacity": 1,
               "overflow": "hidden",
               "paddingHorizontal": 16,
-              "position": "absolute",
-              "right": 0,
             }
           }
         >

--- a/packages/newspringchurchapp/src/prayer/PrayerPreviewCard/index.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerPreviewCard/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import PropTypes from 'prop-types';
 import Color from 'color';
-import { Button, PaddedView, styled } from '@apollosproject/ui-kit';
+import { Button, PaddedView, FlexedView, styled } from '@apollosproject/ui-kit';
 import { withNavigation } from 'react-navigation';
 import PrayerCard from '../PrayerCard';
 // TODO: Borrowed `Overlay` and `getGradientValues` from <GradientOverlayImage />
@@ -39,12 +39,13 @@ const getGradientValues = (overlayColor) => {
   return values;
 };
 
-const StyledButton = styled({
+const BottomView = styled(({ theme }) => ({
   position: 'absolute',
   bottom: 15,
   left: 0,
   right: 0,
-})(Button);
+  marginHorizontal: theme.sizing.baseUnit,
+}))(View);
 
 const PrayerPreviewCard = withNavigation(
   ({ overlayColor, route, ...props }) => (
@@ -56,14 +57,14 @@ const PrayerPreviewCard = withNavigation(
         end={getGradientValues(overlayColor).end}
         locations={getGradientValues(overlayColor).locations}
       />
-      <PaddedView>
-        <StyledButton
+      <BottomView>
+        <Button
           onPress={() =>
             props.navigation.navigate('PrayerList', { list: route })
           }
           title="Start Praying"
         />
-      </PaddedView>
+      </BottomView>
     </>
   )
 );

--- a/packages/newspringchurchapp/src/prayer/PrayerPreviewCard/index.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerPreviewCard/index.js
@@ -3,7 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import PropTypes from 'prop-types';
 import Color from 'color';
-import { Button, PaddedView, FlexedView, styled } from '@apollosproject/ui-kit';
+import { Button, styled } from '@apollosproject/ui-kit';
 import { withNavigation } from 'react-navigation';
 import PrayerCard from '../PrayerCard';
 // TODO: Borrowed `Overlay` and `getGradientValues` from <GradientOverlayImage />

--- a/packages/newspringchurchapp/src/prayer/index.js
+++ b/packages/newspringchurchapp/src/prayer/index.js
@@ -135,7 +135,7 @@ const StyledPaddedView = styled(({ theme }) => ({
 const StyledView = styled(({ theme }) => ({
   height: Dimensions.get('window').height * 0.4,
   justifyContent: 'flex-end',
-  marginTop: theme.sizing.baseUnit * 2,
+  marginTop: theme.sizing.baseUnit,
 }))(View);
 
 const StyledButtonLink = styled(({ theme }) => ({
@@ -146,11 +146,10 @@ const StyledButtonLink = styled(({ theme }) => ({
 const StyledContainer = styled(({ theme }) => ({
   alignItems: 'center',
   marginTop: theme.sizing.baseUnit,
-  marginBottom: theme.sizing.baseUnit,
 }))(View);
 
 const StyledAddPrayerContainer = styled(({ theme }) => ({
-  marginTop: theme.sizing.baseUnit * 2,
+  marginTop: theme.sizing.baseUnit,
 }))(View);
 
 const Tab = ({ index, showAddPrayerCard }) => {


### PR DESCRIPTION

## DESCRIPTION

There was a styling issue where on android the `Start Praying` button on the Prayer Preview Card was not visible.

### What does this PR do, or why is it needed?

This PR moves the styling of the `absolute` positioning to the container of the button, instead of the button itself. It also reduces some of the margin on the components above the button to prevent it from not being presented in the view.

### How do I test this PR?

Fire up the app and navigate to the Prayer Module. Check to see that when you go to a prayer list, the prayer preview card shows the `Start Praying` button.

---

> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [DEV-XXX](#url)
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android if applicable
- [ ] Set two relevant reviewers

## REVIEW

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

---

> The purpose of PR Review is to _improve the quality of the software._
