### PR TITLE
(DEV-3751) Fixes Default Content Color

### DIFF
--- a/packages/apollos-church-api/src/data/content-items/resolver.js
+++ b/packages/apollos-church-api/src/data/content-items/resolver.js
@@ -14,7 +14,7 @@ const resolver = {
     }) => ({
       type: () => 'LIGHT',
       colors: () => ({
-        primary: `${value || 'fff'}`,
+        primary: `${value || '#fff'}`,
         secondary: '#6bac43',
         screen: '#F8F7F4',
         paper: `#fff`,


### PR DESCRIPTION
## DESCRIPTION

Updates the default background color of our content to a valid hex string.

![Screen Shot 2019-05-12 at 4 37 32 PM](https://user-images.githubusercontent.com/2659478/57587539-5e919a00-74d4-11e9-9048-5bc7b18a14e9.png)


### What does this PR do, or why is it needed?

We were getting GraphQL errors on content with no color defined.

### How do I test this PR?

Go to "Series" > "View All"

---

> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes [DEV-3751](https://newspring.atlassian.net/browse/DEV-3751)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set two relevant reviewers

## REVIEW

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

---

> The purpose of PR Review is to _improve the quality of the software._