### PR TITLE
[DEV-3745] Fixes How To Pray Screen Header Buttons

### DIFF
--- a/packages/newspringchurchapp/src/content-single/NavigationHeader.js
+++ b/packages/newspringchurchapp/src/content-single/NavigationHeader.js
@@ -4,7 +4,11 @@ import { ModalViewHeader } from '@apollosproject/ui-kit';
 
 const NavigationHeader = ({ scene, navigation }) => {
   let onBack = null;
-  if (scene.index > 0) onBack = () => navigation.pop();
+  // The isolated prop is for a situation where a content single is navigated to from a separate navigator.
+  // This will only ever be true if that content single cannot navigate to another screen and we need to
+  // navigate back to the previous route.
+  if (scene.index > 0 || navigation.state.params.isolated)
+    onBack = () => navigation.pop();
 
   const onClose = () => {
     // Since we're dealing with nested navigators, we have to trigger two actions:
@@ -20,7 +24,12 @@ const NavigationHeader = ({ scene, navigation }) => {
     navigation.pop();
   };
 
-  return <ModalViewHeader onClose={onClose} onBack={onBack} />;
+  return (
+    <ModalViewHeader
+      onClose={navigation.state.params.isolated ? null : onClose}
+      onBack={onBack}
+    />
+  );
 };
 
 NavigationHeader.propTypes = {

--- a/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCard.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCard.js
@@ -173,6 +173,7 @@ class PrayerCard extends PureComponent {
                   navigation.navigate('ContentSingle', {
                     itemId: 'MediaContentItem:b277f039ce974b99753ad8e6805552c2',
                     itemTitle: 'Learning how to pray like Jesus',
+                    isolated: true,
                   });
                 }}
               >

--- a/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCard.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCard.js
@@ -171,6 +171,7 @@ class PrayerCard extends PureComponent {
                       itemId:
                         'MediaContentItem:b277f039ce974b99753ad8e6805552c2',
                       itemTitle: 'Learning how to pray like Jesus',
+                      isolated: true,
                     });
                   }}
                 >


### PR DESCRIPTION
## DESCRIPTION

We want a user to be able to navigate back to the `prayerlist` when we navigate to the `How To Pray` content single.

### What does this PR do, or why is it needed?

This PR adds the `isolated` prop to the navigation route, which helps the content single header determine which buttons to show. This is scalable to other instances when we want to navigate to a piece of content, but have it be stand alone.

### How do I test this PR?

Navigate to a prayer list then press `How to Pray` then navigate back to the `prayerlist`.

---

> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [DEV-XXX](#url)
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android if applicable
- [ ] Set two relevant reviewers

## REVIEW

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

---

> The purpose of PR Review is to _improve the quality of the software._
