### PR TITLE
[DEV-3780] Fixes Android `How to Pray` Touchable

### DIFF
--- a/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCard.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerCard/PrayerCard.js
@@ -61,6 +61,10 @@ const StyledPrayerHeaderView = styled(({ theme }) => ({
   marginTop: theme.sizing.baseUnit * 0.5,
 }))(View);
 
+const StyledTouchable = styled({
+  zIndex: 2,
+})(Touchable);
+
 class PrayerCard extends PureComponent {
   static navigationOptions = () => ({
     header: null,
@@ -164,19 +168,18 @@ class PrayerCard extends PureComponent {
             ) : null}
             <StyledBodyText>{prayer}</StyledBodyText>
             {showHelp ? (
-              <PaddedView>
-                <Touchable
-                  onPress={() => {
-                    navigation.navigate('ContentSingle', {
-                      itemId:
-                        'MediaContentItem:b277f039ce974b99753ad8e6805552c2',
-                      itemTitle: 'Learning how to pray like Jesus',
-                    });
-                  }}
-                >
+              <StyledTouchable
+                onPress={() => {
+                  navigation.navigate('ContentSingle', {
+                    itemId: 'MediaContentItem:b277f039ce974b99753ad8e6805552c2',
+                    itemTitle: 'Learning how to pray like Jesus',
+                  });
+                }}
+              >
+                <PaddedView>
                   <ChannelLabel icon="information" label="How to Pray?" />
-                </Touchable>
-              </PaddedView>
+                </PaddedView>
+              </StyledTouchable>
             ) : null}
           </StyledCardContent>
         </ExpandedCard>

--- a/packages/newspringchurchapp/src/prayer/PrayerCard/__snapshots__/PrayerCard.tests.js.snap
+++ b/packages/newspringchurchapp/src/prayer/PrayerCard/__snapshots__/PrayerCard.tests.js.snap
@@ -340,25 +340,26 @@ exports[`the PrayerCard component renders a prayer card 1`] = `
               }
             />
             <View
+              accessible={true}
+              isTVSelectable={true}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 Object {
-                  "paddingHorizontal": 16,
-                  "paddingVertical": 16,
+                  "opacity": 1,
+                  "zIndex": 2,
                 }
               }
             >
               <View
-                accessible={true}
-                isTVSelectable={true}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
-                    "opacity": 1,
+                    "paddingHorizontal": 16,
+                    "paddingVertical": 16,
                   }
                 }
               >


### PR DESCRIPTION
## DESCRIPTION

Currently tapping on the how to pray touchable triggers the card touchable.

### What does this PR do, or why is it needed?

This PR adds zIndex to the button so that it can be tapped. Also moved the `paddedView` inside the touchable.

### How do I test this PR?

Fire up android sim, go to prayer list and tap on the button.

---

> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [DEV-XXX](#url)
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android if applicable
- [ ] Set two relevant reviewers

## REVIEW

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

---

> The purpose of PR Review is to _improve the quality of the software._
