### PR TITLE
[DEV-3813] Removes Give Feedback from Settings

### DIFF
--- a/packages/newspringchurchapp/src/user-settings/index.js
+++ b/packages/newspringchurchapp/src/user-settings/index.js
@@ -95,18 +95,6 @@ class UserSettings extends PureComponent {
                     </TableView>
                     <TableView>
                       <Touchable
-                        onPress={() =>
-                          openUrl('https://forms.gle/qzYecHmKLci6b4y38')
-                        }
-                      >
-                        <Cell>
-                          <CellText>Give Feedback</CellText>
-                          <CellIcon name="arrow-next" />
-                        </Cell>
-                      </Touchable>
-                    </TableView>
-                    <TableView>
-                      <Touchable
                         onPress={() => openUrl('https://newspring.cc/privacy')}
                       >
                         <Cell>


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

This PR removes the `Give Feedback` link from the Settings menu. We have the better link to our beta-test workflow on the Connect screen itself, so this is obsolete.

### How do I test this PR?

Fire up the sim and make sure it's not in the settings menu

---

> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [DEV-XXX](#url)
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android if applicable
- [ ] Set two relevant reviewers

## REVIEW

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

---

> The purpose of PR Review is to _improve the quality of the software._
