### PR TITLE
[DEV-3797] Fixes LocationFinder to use the User's Location

### DIFF
--- a/packages/newspringchurchapp/src/user-settings/Locations/Locations.tests.js
+++ b/packages/newspringchurchapp/src/user-settings/Locations/Locations.tests.js
@@ -80,6 +80,10 @@ describe('Display Native Map with Locations', () => {
     latitudeDelta: 100,
     longitudeDelta: 10,
   };
+  const userLocation = {
+    latitude: 34.59778,
+    longitude: -82.62259,
+  };
   it('Render a native map view', async () => {
     const navigation = {
       navigate: jest.fn(),
@@ -91,8 +95,8 @@ describe('Display Native Map with Locations', () => {
       request: {
         query: getCampusLocations,
         variables: {
-          latitude: initialRegion.latitude,
-          longitude: initialRegion.longitude,
+          latitude: userLocation.latitude,
+          longitude: userLocation.longitude,
         },
       },
       result: {

--- a/packages/newspringchurchapp/src/user-settings/Locations/index.js
+++ b/packages/newspringchurchapp/src/user-settings/Locations/index.js
@@ -61,7 +61,10 @@ class Location extends PureComponent {
   });
 
   state = {
-    region: this.props.initialRegion,
+    userLocation: {
+      latitude: 34.59778,
+      longitude: -82.62259,
+    },
   };
 
   componentDidMount() {
@@ -89,8 +92,8 @@ class Location extends PureComponent {
       <Query
         query={getAllCampuses}
         variables={{
-          latitude: this.state.region.latitude,
-          longitude: this.state.region.longitude,
+          latitude: this.state.userLocation.latitude,
+          longitude: this.state.userLocation.longitude,
         }}
         fetchPolicy="cache-and-network"
       >


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Currently, the onboarding locationfinder and Location in the user-settings menu use the `initialRegion` lat and long, which are somewhere in Kansas. This corrects that usage to make it so that the user's location is the one used to determine campus distance.

### How do I test this PR?
Go to Locations or run through onboarding and make sure that the campuses have the correct distance and that they are ordered correctly.

---

> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [DEV-XXX](#url)
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android if applicable
- [ ] Set two relevant reviewers

## REVIEW

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

---

> The purpose of PR Review is to _improve the quality of the software._
