### PR TITLE
[DEV-3850] Updates Initial Coordinates to just SC

### DIFF
--- a/packages/newspringchurchapp/android/app/src/main/AndroidManifest.xml
+++ b/packages/newspringchurchapp/android/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />
-          <data android:scheme="peopleapp" android:host="people" /> // A
+          <data android:scheme="peopleapp" android:host="people" />
         </intent-filter>
       </activity>
       <activity

--- a/packages/newspringchurchapp/src/user-settings/Locations/index.js
+++ b/packages/newspringchurchapp/src/user-settings/Locations/index.js
@@ -43,10 +43,10 @@ class Location extends PureComponent {
   static defaultProps = {
     initialRegion: {
       // roughly show the entire USA by default
-      latitude: 39.809734,
-      longitude: -98.555618,
-      latitudeDelta: 100,
-      longitudeDelta: 100 * ASPECT_RATIO,
+      latitude: 32.916107,
+      longitude: -80.974731,
+      latitudeDelta: 8,
+      longitudeDelta: 5 * ASPECT_RATIO,
     },
   };
 


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

On the Locationfinder, we want the view to be more usable for our users. Currently the initial view is set to the entire US. This PR updates this to be just of SC.

Also, I kept getting an error on android build from a random useless comment that _I_ somehow added back in October. I took that out as well.

### How do I test this PR?

Navigate to the Locationfinder in the settings tab and see if it shows just SC.

---

> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android if applicable
- [ ] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
