### PR TITLE
Fixed a Null Campus Causing No Prayers to Display

### DIFF
--- a/packages/apollos-data-prayer/src/prayer-requests/resolver.js
+++ b/packages/apollos-data-prayer/src/prayer-requests/resolver.js
@@ -79,9 +79,8 @@ export default {
   PrayerRequest: {
     id: ({ id }, args, context, { parentType }) =>
       createGlobalId(id, parentType.name),
-    campus: ({ campusId }, args, { dataSources }) => {
-      return isNumber(campusId) ? dataSources.Campus.getFromId(campusId) : null;
-    },
+    campus: ({ campusId }, args, { dataSources }) =>
+      isNumber(campusId) ? dataSources.Campus.getFromId(campusId) : null,
     isAnonymous: ({ attributeValues: { isAnonymous: { value } = {} } = {} }) =>
       value === 'True',
     person: ({ requestedByPersonAliasId }, args, { dataSources }) =>

--- a/packages/apollos-data-prayer/src/prayer-requests/resolver.js
+++ b/packages/apollos-data-prayer/src/prayer-requests/resolver.js
@@ -1,5 +1,5 @@
 import { createGlobalId, parseGlobalId } from '@apollosproject/server-core';
-import { uniq } from 'lodash';
+import { uniq, isNumber } from 'lodash';
 
 export default {
   Query: {
@@ -79,8 +79,9 @@ export default {
   PrayerRequest: {
     id: ({ id }, args, context, { parentType }) =>
       createGlobalId(id, parentType.name),
-    campus: ({ campusId }, args, { dataSources }) =>
-      dataSources.Campus.getFromId(campusId),
+    campus: ({ campusId }, args, { dataSources }) => {
+      return isNumber(campusId) ? dataSources.Campus.getFromId(campusId) : null;
+    },
     isAnonymous: ({ attributeValues: { isAnonymous: { value } = {} } = {} }) =>
       value === 'True',
     person: ({ requestedByPersonAliasId }, args, { dataSources }) =>


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
If a prayer does not have a campus then the query for prayers would fail and the app would not show any prayers. This PR adds a check to correctly handle this situation so that the query will not fail and the app will continue to display prayers.

### How do I test this PR?
Make sure that your sim is pointed toward `alpha-rock` (where we have a prayer without a campus). 
Run the sim from the `master` branch and you will not have any prayers show up in tabs like `My Church`. 
Pull this branch and run the sim again. Now you should have prayers show up correctly.

---
> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
