### PR TITLE
(DEV-3904) Fixes Add Prayer Form

### DIFF
--- a/packages/apollos-church-api/config.yml
+++ b/packages/apollos-church-api/config.yml
@@ -120,6 +120,9 @@ ROCK_MAPPINGS:
 
   PRAYER_MENU_CATEGORIES_CHANNEL_ID: 440
 
+  WEB_CAMPUS_ID: 20
+  GENERAL_PRAYER_CATEGORY_ID: 2
+
 # Default mapping of field types -> ids. There's probably no reason to edit this.
 ROCK_CONSTANTS:
   TEXT: 1

--- a/packages/apollos-data-prayer/src/prayer-requests/data-source.js
+++ b/packages/apollos-data-prayer/src/prayer-requests/data-source.js
@@ -151,8 +151,11 @@ export default class PrayerRequest extends RockApolloDataSource {
         FirstName: firstName, // Required by Rock
         LastName: lastName,
         Text: text, // Required by Rock
-        CategoryId: categoryId,
-        CampusId: parseInt(parseGlobalId(campusId).id, 10),
+        CategoryId: categoryId || ROCK_MAPPINGS.GENERAL_PRAYER_CATEGORY_ID,
+        // default to web campus
+        CampusId: campusId
+          ? parseInt(parseGlobalId(campusId).id, 10)
+          : ROCK_MAPPINGS.WEB_CAMPUS_ID,
         IsPublic: true,
         RequestedByPersonAliasId: primaryAliasId,
         IsActive: true,

--- a/packages/apollos-data-prayer/src/prayer-requests/schema.js
+++ b/packages/apollos-data-prayer/src/prayer-requests/schema.js
@@ -10,8 +10,8 @@ const prayerRequestSchema = gql`
   }
   extend type Mutation {
     addPrayer(
-      campusId: String!
-      categoryId: Int!
+      campusId: String
+      categoryId: Int
       text: String!
       firstName: String!
       lastName: String

--- a/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/AddPrayerFormConnected.js
+++ b/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/AddPrayerFormConnected.js
@@ -34,11 +34,21 @@ class AddPrayerFormConnected extends React.Component {
                 onSubmit={(values) => {
                   addPrayer({
                     variables: {
-                      campusId: get(userData, 'currentUser.profile.campus.id'),
+                      // web campus by default
+                      campusId: get(
+                        userData,
+                        'currentUser.profile.campus.id',
+                        20
+                      ),
                       // TODO: make this dynamic
                       categoryId: 2,
                       text: values.prayer,
-                      firstName: get(userData, 'currentUser.profile.firstName'),
+                      // Unknown by default
+                      firstName: get(
+                        userData,
+                        'currentUser.profile.firstName',
+                        'Unknown'
+                      ),
                       lastName: get(userData, 'currentUser.profile.lastName'),
                       isAnonymous: values.anonymous,
                     },

--- a/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/AddPrayerFormConnected.js
+++ b/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/AddPrayerFormConnected.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Query, Mutation } from 'react-apollo';
-import { get } from 'lodash';
 import getUserProfile from 'newspringchurchapp/src/tabs/connect/getUserProfile';
 import GET_USER_PRAYERS from 'newspringchurchapp/src/prayer/data/queries/getUserPrayers';
 import ADD_PRAYER from '../../data/mutations/addPrayer';
@@ -13,52 +12,37 @@ class AddPrayerFormConnected extends React.Component {
 
   render() {
     return (
-      <Query query={getUserProfile} fetchPolicy={'cache-only'}>
-        {({ data: userData }) => (
-          <Mutation
-            mutation={ADD_PRAYER}
-            update={(cache, { data: { addPrayer } }) => {
-              const { userPrayers } = cache.readQuery({
-                query: GET_USER_PRAYERS,
-              });
-              cache.writeQuery({
-                query: GET_USER_PRAYERS,
-                data: {
-                  userPrayers: userPrayers.concat([addPrayer]),
-                },
-              });
-            }}
-          >
+      <Query query={getUserProfile}>
+        {({
+          data: {
+            currentUser: {
+              profile: {
+                campus: { id: campusId } = {},
+                firstName,
+                lastName,
+                photo = { uri: null },
+              } = {},
+            } = {},
+          } = {},
+        }) => (
+          <Mutation mutation={ADD_PRAYER}>
             {(addPrayer) => (
               <AddPrayerForm
                 onSubmit={(values) => {
                   addPrayer({
                     variables: {
-                      // web campus by default
-                      campusId: get(
-                        userData,
-                        'currentUser.profile.campus.id',
-                        20
-                      ),
-                      // TODO: make this dynamic
-                      categoryId: 2,
+                      campusId,
                       text: values.prayer,
-                      // Unknown by default
-                      firstName: get(
-                        userData,
-                        'currentUser.profile.firstName',
-                        'Unknown'
-                      ),
-                      lastName: get(userData, 'currentUser.profile.lastName'),
+                      firstName,
+                      lastName,
                       isAnonymous: values.anonymous,
                     },
+                    refetchQueries: [{ query: GET_USER_PRAYERS }],
                   });
                   // TODO: wonder if this should be tied to the ModalView onClose method???
                   this.props.navigation.pop();
                 }}
-                avatarSource={get(userData, 'currentUser.profile.photo', {
-                  uri: null,
-                })}
+                avatarSource={photo}
                 {...this.props}
                 onClose={() => this.props.navigation.pop()}
               />

--- a/packages/newspringchurchapp/src/prayer/data/mutations/addPrayer.js
+++ b/packages/newspringchurchapp/src/prayer/data/mutations/addPrayer.js
@@ -2,8 +2,8 @@ import gql from 'graphql-tag';
 
 export default gql`
   mutation AddPrayer(
-    $campusId: String!
-    $categoryId: Int!
+    $campusId: String
+    $categoryId: Int
     $text: String!
     $firstName: String!
     $lastName: String


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Currently adding prayers is all kinds of broken this solves a bunch of issues:

- Removes `categoryId` from the client entirely and justs sets the default to 2 (General) driven from `config.yml`
- Sets default campus (Web) in API driven off `config.yml` if none provided
- Default first name set to "Unknown" client-side (may not be needed :))
- Removes `cache-only` policy from `addPrayers` because the `getCurrentUser` hadn't been run yet, breaking everything
- Removes the `update` prop on the mutation in favor of the `refetchQueries` function. Because `GET_USER_PRAYERS` didn't exist in cache yet, throwing an error.

### How do I test this PR?

Add some prayers!

---

> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._