### PR TITLE
(DEV-3909) Fixes Saved Prayers

### DIFF
--- a/packages/apollos-data-prayer/src/prayer-requests/resolver.js
+++ b/packages/apollos-data-prayer/src/prayer-requests/resolver.js
@@ -1,5 +1,5 @@
 import { createGlobalId, parseGlobalId } from '@apollosproject/server-core';
-import { uniq, isNumber } from 'lodash';
+import { isNumber } from 'lodash';
 
 export default {
   Query: {
@@ -11,25 +11,8 @@ export default {
       dataSources.PrayerRequest.getFromCurrentPerson(),
     groupPrayers: (root, args, { dataSources }) =>
       dataSources.PrayerRequest.getFromGroups(),
-    savedPrayers: async (root, args, { dataSources }) => {
-      try {
-        const followings = await dataSources.Followings.getFollowingsForCurrentUser(
-          {
-            type: 'PrayerRequest',
-          }
-        );
-
-        const stuff = await followings.get();
-        const prayerIds = stuff.map((follow) => follow.entityId);
-        const prayers = await dataSources.PrayerRequest.getFromIds(
-          uniq(prayerIds)
-        ).get();
-
-        return prayers;
-      } catch (err) {
-        throw new Error(err);
-      }
-    },
+    savedPrayers: async (root, args, { dataSources }) =>
+      dataSources.PrayerRequest.getSavedPrayers(),
   },
   Mutation: {
     addPrayer: (root, args, { dataSources }) =>


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Currenly querying for saved prayers when you don't have any is broken.

### How do I test this PR?

Unsave all your prayers and then query `savedPrayers` from the API.

---

> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._