### PR TITLE
[DEV-3907] Reset Prayer Text on Submit

### DIFF
--- a/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/AddPrayerForm.js
+++ b/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/AddPrayerForm.js
@@ -53,7 +53,10 @@ const AddPrayerForm = memo(
   ({ onSubmit, avatarSource, title, btnLabel, ...props }) => (
     <Formik
       initialValues={{ prayer: '', anonymous: false }}
-      onSubmit={onSubmit}
+      onSubmit={(values, { resetForm }) => {
+        onSubmit(values);
+        resetForm({});
+      }}
     >
       {({ handleChange, handleBlur, handleSubmit, values }) => (
         <ModalView {...props}>
@@ -73,7 +76,7 @@ const AddPrayerForm = memo(
                   placeholder="Start typing your prayer..."
                   onChangeText={handleChange('prayer')}
                   onBlur={handleBlur('prayer')}
-                  value={values.prayer}
+                  value={values.prayer || ''}
                   underline={false}
                 />
               </InputPaddedView>


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR resets the Add Prayer Form prayer text when the form is submitted.

### How do I test this PR?
Fire up that sim, add a prayer, tap "Add Another Prayer Request", and make sure that the prayer text has been cleared out.

---
> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
