### PR TITLE
[DEV-3917] Prayer Menu Ordered Correctly

### DIFF
--- a/packages/apollos-data-prayer/src/prayer-menu-categories/data-source.js
+++ b/packages/apollos-data-prayer/src/prayer-menu-categories/data-source.js
@@ -10,6 +10,7 @@ class PrayerMenuCategory extends ContentItem.dataSource {
       .filter(
         `ContentChannelId eq ${ROCK_MAPPINGS.PRAYER_MENU_CATEGORIES_CHANNEL_ID}`
       )
+      .orderBy('Order')
       .get();
     const {
       dataSources: { Auth, Campus },


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR orders the prayer menu based off of the order set in the Rock prayer menu content channel.

### How do I test this PR?
Run the sim and make sure that the menu is in the right order based on the content channel. You will probably have to delete your app and reinstall it to make sure that it isn't cached.

---
> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
