### PR TITLE
[DEV-3937] Adds UI for Free Form Notes

### DIFF
--- a/packages/newspringchurchapp/src/content-single/Features/TextFeature.js
+++ b/packages/newspringchurchapp/src/content-single/Features/TextFeature.js
@@ -32,7 +32,7 @@ const TextFeature = ({ body, contentId }) => {
         icon={'play'}
         action={
           <ShareButton
-            title={`${bodyWithWord} || My Notes: ${notesText.text}`}
+            title={`${bodyWithWord}\nNotes: ${notesText.text}`}
             itemId={contentId}
           />
         }

--- a/packages/newspringchurchapp/src/content-single/Features/TextFeature.js
+++ b/packages/newspringchurchapp/src/content-single/Features/TextFeature.js
@@ -20,19 +20,29 @@ const StyledTextInput = styled(({ theme }) => ({
 
 const TextFeature = ({ body, contentId }) => {
   const [isPressed, press] = useState(false);
+  const [notesText, setNotesText] = useState('');
   const bodyWithBlank = body.replace(/__(.*)__/gm, (match, p1) =>
     '_'.repeat(p1.length)
   );
   const bodyWithWord = body.replace(/__(.*)__/gm, (match, p1) => p1);
+  console.log(notesText);
 
   return (
     <TouchableOpacity onPress={() => press(true)}>
       <ActionCard
         icon={'play'}
-        action={<ShareButton message={body} itemId={contentId} />}
+        action={
+          <ShareButton
+            title={`${bodyWithWord} || My Notes: ${notesText.text}`}
+            itemId={contentId}
+          />
+        }
       >
         <BodyText>{isPressed ? bodyWithWord : bodyWithBlank}</BodyText>
-        <StyledTextInput multiline />
+        <StyledTextInput
+          multiline
+          onChangeText={(text) => setNotesText({ text })}
+        />
       </ActionCard>
     </TouchableOpacity>
   );

--- a/packages/newspringchurchapp/src/content-single/Features/TextFeature.js
+++ b/packages/newspringchurchapp/src/content-single/Features/TextFeature.js
@@ -2,8 +2,21 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { TouchableOpacity } from 'react-native';
 
-import { ActionCard, BodyText } from '@apollosproject/ui-kit';
+import {
+  ActionCard,
+  BodyText,
+  TextInput,
+  styled,
+} from '@apollosproject/ui-kit';
 import ShareButton from 'newspringchurchapp/src/ui/ShareButton';
+
+const StyledTextInput = styled(({ theme }) => ({
+  height: theme.sizing.baseUnit * 6,
+  borderWidth: 0.5,
+  borderColor: theme.colors.shadows.default,
+  paddingHorizontal: theme.sizing.baseUnit * 0.5,
+  textAlignVertical: 'top',
+}))(TextInput);
 
 const TextFeature = ({ body, contentId }) => {
   const [isPressed, press] = useState(false);
@@ -19,6 +32,7 @@ const TextFeature = ({ body, contentId }) => {
         action={<ShareButton message={body} itemId={contentId} />}
       >
         <BodyText>{isPressed ? bodyWithWord : bodyWithBlank}</BodyText>
+        <StyledTextInput multiline />
       </ActionCard>
     </TouchableOpacity>
   );

--- a/packages/newspringchurchapp/src/content-single/Features/TextFeature.js
+++ b/packages/newspringchurchapp/src/content-single/Features/TextFeature.js
@@ -25,7 +25,6 @@ const TextFeature = ({ body, contentId }) => {
     '_'.repeat(p1.length)
   );
   const bodyWithWord = body.replace(/__(.*)__/gm, (match, p1) => p1);
-  console.log(notesText);
 
   return (
     <TouchableOpacity onPress={() => press(true)}>


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

We want to add free form notes to our weekend experience. This brings it in.

![Kapture 2019-07-29 at 14 57 43](https://user-images.githubusercontent.com/8878532/62074690-4a2a8700-b211-11e9-8df4-9a457d1b973c.gif)

This will be in conjunction of another PR that allows it to be exported.

### How do I test this PR?

On alpha-rock, go to the 'Live for Freedom' sermon series and look at the fill in the blanks.

---

> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android if applicable
- [ ] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._

