### PR TITLE
(DEV-3948) Adds Date to Sermon API

### DIFF
--- a/packages/apollos-church-api/config.yml
+++ b/packages/apollos-church-api/config.yml
@@ -76,6 +76,7 @@ ROCK_MAPPINGS:
       EntityType: ContentChannelItem
     WeekendContentItem:
       EntityType: ContentChannelItem
+      ContentChannelId: [19]
     ContentItem:
       EntityType: ContentChannelItem
 
@@ -94,6 +95,7 @@ ROCK_MAPPINGS:
     - 27
     - 16
     - 18
+    - 19
     - 20
     - 28
 

--- a/packages/apollos-church-api/src/data/index.js
+++ b/packages/apollos-church-api/src/data/index.js
@@ -23,6 +23,7 @@ import {
 } from '@apollosproject/data-connector-rock';
 import * as Theme from './theme';
 import * as ExtendedPerson from './people';
+import * as WeekendContentItem from './weekend-content-items';
 import * as ContentItem from './content-items';
 import * as Campus from './campuses';
 import * as Interactions from './interactions';
@@ -36,6 +37,7 @@ const data = {
   Followings,
   ContentChannel,
   ContentItem,
+  WeekendContentItem,
   Person,
   ExtendedPerson,
   Auth,

--- a/packages/apollos-church-api/src/data/weekend-content-items/data-source.js
+++ b/packages/apollos-church-api/src/data/weekend-content-items/data-source.js
@@ -1,0 +1,3 @@
+import { ContentItem as baseContentItem } from '@apollosproject/data-connector-rock';
+
+export default class ContentItem extends baseContentItem.dataSource {}

--- a/packages/apollos-church-api/src/data/weekend-content-items/index.js
+++ b/packages/apollos-church-api/src/data/weekend-content-items/index.js
@@ -1,0 +1,5 @@
+import schema from './schema';
+import resolver from './resolver';
+import dataSource from './data-source';
+
+export { schema, resolver, dataSource };

--- a/packages/apollos-church-api/src/data/weekend-content-items/resolver.js
+++ b/packages/apollos-church-api/src/data/weekend-content-items/resolver.js
@@ -3,7 +3,7 @@ import { resolverMerge } from '@apollosproject/server-core';
 
 const resolver = {
   WeekendContentItem: {
-    communicator: (parent, args, context) => null,
+    communicator: () => null,
     sermonDate: ({ attributeValues: { actualDate: { value } = {} } = {} }) =>
       value,
   },

--- a/packages/apollos-church-api/src/data/weekend-content-items/resolver.js
+++ b/packages/apollos-church-api/src/data/weekend-content-items/resolver.js
@@ -1,0 +1,11 @@
+import { ContentItem as baseContentItem } from '@apollosproject/data-connector-rock';
+import { resolverMerge } from '@apollosproject/server-core';
+
+const resolver = {
+  WeekendContentItem: {
+    communicator: (parent, args, context) => null,
+    sermonDate: ({ attributeValues: { actualDate: { value } = {} } = {} }) =>
+      value,
+  },
+};
+export default resolverMerge(resolver, baseContentItem);

--- a/packages/apollos-church-api/src/data/weekend-content-items/schema.js
+++ b/packages/apollos-church-api/src/data/weekend-content-items/schema.js
@@ -1,0 +1,8 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  extend type WeekendContentItem {
+    communicator: Person
+    sermonDate: String
+  }
+`;


### PR DESCRIPTION
## DESCRIPTION

<img width="1389" alt="Screen Shot 2019-08-05 at 3 34 41 PM" src="https://user-images.githubusercontent.com/2659478/62490140-99833100-b796-11e9-856d-b9c1f8cece57.png">


### What does this PR do, or why is it needed?

Adds `sermonDate` as a field on a `WeekendContentItem`

### How do I test this PR?

run this:

```
{
  userFeed {
    edges {
      node {
        title
        id
        ... on WeekendContentItem {
          sermonDate
        }
      }
    }
  }
}
```

---

> I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))

## TODO

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._