### PR TITLE
(DEV-3988) Optimizes Prayer Loading

### DIFF
--- a/packages/newspringchurchapp/package.json
+++ b/packages/newspringchurchapp/package.json
@@ -73,6 +73,7 @@
       "postbump": "yarn postversion"
     },
     "skip": {
+      "tag": true,
       "commit": true
     }
   },

--- a/packages/newspringchurchapp/src/prayer/PrayerTabView/index.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerTabView/index.js
@@ -32,6 +32,7 @@ class PrayerTabView extends PureComponent {
         key: PropTypes.string,
       })
     ),
+    campusID: PropTypes.string,
   };
 
   static defaultProps = {
@@ -63,41 +64,28 @@ class PrayerTabView extends PureComponent {
           width: Dimensions.get('window').width,
         }}
         navigationState={{ ...this.state }}
-        renderScene={({ route }) => (
-          // TODO: ideally we just pull this from cache and don't have to run this
-          <Query query={getUserProfile}>
-            {({
-              data: {
-                currentUser: {
-                  profile: { campus: { id = '' } = {} } = {},
-                } = {},
-              } = {},
-              loading: profileLoading,
-            }) => {
-              if (profileLoading) return null;
-              return (
-                <Query
-                  query={this.queries[route.key]}
-                  variables={{ campusId: id }}
-                  fetchPolicy="cache-and-network"
-                >
-                  {({ data, loading: prayersLoading }) => (
-                    <PrayerTab
-                      loading={prayersLoading}
-                      prayers={
-                        data && data.length > 0 ? Object.values(data)[0] : []
-                      }
-                      description={route.description}
-                      title={route.title}
-                      type={route.key.split('-')[1]}
-                      {...this.props}
-                    />
-                  )}
-                </Query>
-              );
-            }}
-          </Query>
-        )}
+        renderScene={({ route }) =>
+          this.props.campusID === '' ? null : (
+            <Query
+              query={this.queries[route.key]}
+              variables={{ campusId: this.props.campusID }}
+              fetchPolicy="cache-and-network"
+            >
+              {({ data, loading: prayersLoading }) => (
+                <PrayerTab
+                  loading={prayersLoading}
+                  prayers={
+                    data && data.length > 0 ? Object.values(data)[0] : []
+                  }
+                  description={route.description}
+                  title={route.title}
+                  type={route.key.split('-')[1]}
+                  {...this.props}
+                />
+              )}
+            </Query>
+          )
+        }
         renderTabBar={(props) => (
           <StyledHorizontalTileFeed
             content={this.props.categories}

--- a/packages/newspringchurchapp/src/prayer/PrayerTabView/index.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerTabView/index.js
@@ -84,7 +84,9 @@ class PrayerTabView extends PureComponent {
                   {({ data, loading: prayersLoading }) => (
                     <PrayerTab
                       loading={prayersLoading}
-                      prayers={!prayersLoading ? Object.values(data)[0] : []}
+                      prayers={
+                        data && data.length > 0 ? Object.values(data)[0] : []
+                      }
                       description={route.description}
                       title={route.title}
                       type={route.key.split('-')[1]}

--- a/packages/newspringchurchapp/src/prayer/PrayerTabView/index.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerTabView/index.js
@@ -74,7 +74,9 @@ class PrayerTabView extends PureComponent {
                 <PrayerTab
                   loading={prayersLoading}
                   prayers={
-                    data && data.length > 0 ? Object.values(data)[0] : []
+                    data && Object.values(data).length > 0
+                      ? Object.values(data)[0]
+                      : []
                   }
                   description={route.description}
                   title={route.title}

--- a/packages/newspringchurchapp/src/prayer/PrayerTabView/index.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerTabView/index.js
@@ -10,7 +10,6 @@ import {
 } from '@apollosproject/ui-kit';
 import PrayerMenuCard from '../PrayerMenuCard';
 
-import getUserProfile from '../../tabs/connect/getUserProfile';
 import GET_GROUP_PRAYERS from '../data/queries/getGroupPrayers';
 import GET_PRAYERS from '../data/queries/getPrayers';
 import GET_CAMPUS_PRAYERS from '../data/queries/getCampusPrayers';

--- a/packages/newspringchurchapp/src/prayer/index.js
+++ b/packages/newspringchurchapp/src/prayer/index.js
@@ -1,6 +1,8 @@
 import React, { PureComponent } from 'react';
 import { Query } from 'react-apollo';
 import { ActivityIndicator } from '@apollosproject/ui-kit';
+import { client } from '../client';
+import GET_USER_PROFILE from '../tabs/connect/getUserProfile';
 import GET_PRAYER_MENU_CATEGORIES from './data/queries/getPrayerMenuCategories';
 import PrayerMenu from './PrayerMenu';
 
@@ -9,6 +11,10 @@ class PrayerMenuConnected extends PureComponent {
     title: 'Prayer',
     header: null,
   });
+
+  componentDidMount() {
+    client.query({ query: GET_USER_PROFILE });
+  }
 
   render() {
     return (

--- a/packages/newspringchurchapp/src/prayer/index.js
+++ b/packages/newspringchurchapp/src/prayer/index.js
@@ -12,8 +12,17 @@ class PrayerMenuConnected extends PureComponent {
     header: null,
   });
 
-  componentDidMount() {
-    client.query({ query: GET_USER_PROFILE });
+  state = {
+    userCampusID: null,
+  };
+
+  async componentDidMount() {
+    const {
+      data: {
+        currentUser: { profile: { campus: { id = '' } = {} } = {} } = {},
+      } = {},
+    } = await client.query({ query: GET_USER_PROFILE });
+    this.setState({ userCampusID: id });
   }
 
   render() {
@@ -28,7 +37,13 @@ class PrayerMenuConnected extends PureComponent {
             title: category.title,
             key: category.key,
           }));
-          return <PrayerMenu categories={categories} {...this.props} />;
+          return (
+            <PrayerMenu
+              categories={categories}
+              campusID={this.state.userCampusID}
+              {...this.props}
+            />
+          );
         }}
       </Query>
     );


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

This pulls out the `currentUser` query from the `renderScene` function of the `PrayerTabView` and passes in that data as a prop. Much fewer data calls. Also fixes an error we've been having.

### How do I test this PR?

Pull up the prayer menu.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._