### PR TITLE
[DEV-3987] Fixes ContentSeriesContentItem text color

### DIFF
--- a/packages/apollos-church-api/src/data/content-items/resolver.js
+++ b/packages/apollos-church-api/src/data/content-items/resolver.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { ContentItem as originalContentItem } from '@apollosproject/data-connector-rock';
 import { resolverMerge } from '@apollosproject/server-core';
 
@@ -10,21 +9,6 @@ const resolver = {
   Query: {
     contentItemFromSlug: (root, { slug }, { dataSources }) =>
       dataSources.ContentItem.getBySlug(slug),
-  },
-  ContentSeriesContentItem: {
-    theme: (contentItem) => ({
-      type: () => 'LIGHT',
-      colors: () => ({
-        primary: `${get(
-          contentItem,
-          'attributeValues.backgroundColor.value',
-          '#fff'
-        )}`,
-        secondary: '#6bac43',
-        screen: '#F8F7F4',
-        paper: `#fff`,
-      }),
-    }),
   },
   DevotionalContentItem: {
     scriptures: async ({ id }, args, { dataSources }) => {

--- a/packages/newspringchurchapp/src/linking/Provider.js
+++ b/packages/newspringchurchapp/src/linking/Provider.js
@@ -32,7 +32,6 @@ class ExternalLinkProvider extends Component {
   static navigationOptions = {};
 
   componentDidMount() {
-    console.log('within componentDidMount');
     Linking.addEventListener('url', this._handleOpenURL);
     Linking.getInitialURL().then((url) => {
       if (url) {


### PR DESCRIPTION
#237  DESCRIPTION

### What does this PR do, or why is it needed?

We were setting a custom theming specifically for `ContentSeriesContentItem` that was pulling colors that did not match our theme.


![Screen Shot 2019-09-10 at 10 08 06 AM](https://user-images.githubusercontent.com/8878532/64621034-f9cb4b00-d3b2-11e9-9f90-a3915486a59d.png)


This also removed a console.log from a provider from a previous PR

### How do I test this PR?

Go to the discover tab and make sure that the devotional and sermon series tile images have white text.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._