### PR TITLE
Change Prayer Button Text

### DIFF
--- a/packages/newspringchurchapp/src/prayer/PrayerList/index.js
+++ b/packages/newspringchurchapp/src/prayer/PrayerList/index.js
@@ -140,9 +140,7 @@ class PrayerList extends PureComponent {
                       {!this.state.prayed ? (
                         <View>
                           <Button
-                            title={`I've prayed for ${
-                              prayer.isAnonymous ? 'request' : prayer.firstName
-                            }`}
+                            title={`I've prayed`}
                             onPress={() => {
                               increment({
                                 variables: { parsedId: prayer.id },


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Changes the text to say "I've prayed" instead of "I've prayed for [NAME]". The latter is misleading as I may not be praying for that person individually but something they have asked the user to pray for.

### How do I test this PR?

Just pull up the screen.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._