### PR TITLE
(DEV-4013) Changes style of content categories

### DIFF
--- a/packages/apollos-church-api/src/data/content-items/resolver.js
+++ b/packages/apollos-church-api/src/data/content-items/resolver.js
@@ -13,14 +13,6 @@ const defaultResolvers = {
     title: 'Share via ...',
     message: `${root.title} - ${ContentItem.createSummary(root)}`,
   }),
-  parentChannel: async ({ contentChannelId }, args, { dataSources }) => {
-    let channelName = await dataSources.ContentChannel.getFromId(
-      contentChannelId
-    );
-    // our content channels are prefixed with NewSpring, remove that
-    channelName = channelName.replace('NewSpring - ', '');
-    return channelName;
-  },
 };
 
 const resolver = {

--- a/packages/apollos-church-api/src/data/content-items/resolver.js
+++ b/packages/apollos-church-api/src/data/content-items/resolver.js
@@ -13,6 +13,14 @@ const defaultResolvers = {
     title: 'Share via ...',
     message: `${root.title} - ${ContentItem.createSummary(root)}`,
   }),
+  parentChannel: async ({ contentChannelId }, args, { dataSources }) => {
+    let channelName = await dataSources.ContentChannel.getFromId(
+      contentChannelId
+    );
+    // our content channels are prefixed with NewSpring, remove that
+    channelName = channelName.replace('NewSpring - ', '');
+    return channelName;
+  },
 };
 
 const resolver = {

--- a/packages/newspringchurchapp/src/tabs/discover/Discover.js
+++ b/packages/newspringchurchapp/src/tabs/discover/Discover.js
@@ -21,7 +21,7 @@ class Discover extends PureComponent {
   renderItem = ({ item }) => (
     <TileContentFeed
       id={item.id}
-      name={item.name}
+      name={item.name.replace('NewSpring - ', '')}
       content={get(item, 'childContentItemsConnection.edges', []).map(
         (edge) => edge.node
       )}

--- a/packages/newspringchurchapp/src/tabs/home/Features/index.js
+++ b/packages/newspringchurchapp/src/tabs/home/Features/index.js
@@ -101,7 +101,10 @@ const Features = memo(({ navigation }) => (
                     <H3 numberOfLines={3}>{subtitle}</H3>
                   </>
                 }
-                actions={actions}
+                actions={actions.map((action) => ({
+                  ...action,
+                  subtitle: action.subtitle.replace('NewSpring - ', ''),
+                }))}
                 onPressActionItem={({ action, relatedNode }) => {
                   if (action === 'READ_CONTENT') {
                     navigation.navigate('ContentSingle', {

--- a/packages/newspringchurchapp/src/ui/ContentCardConnected/ContentCardConnected.js
+++ b/packages/newspringchurchapp/src/ui/ContentCardConnected/ContentCardConnected.js
@@ -28,7 +28,9 @@ const ContentCardConnected = memo(
               {...node}
               hasAction={hasMedia}
               isLive={isLive}
-              labelText={labelText}
+              labelText={
+                labelText ? labelText.replace('NewSpring - ', '') : null
+              }
               {...otherProps}
               coverImage={coverImage}
               isLoading={loading}


### PR DESCRIPTION
## DESCRIPTION

<img width="463" alt="Screen Shot 2019-09-30 at 9 48 27 AM" src="https://user-images.githubusercontent.com/2659478/65884881-9ad07480-e367-11e9-8bd4-cf8c3eab97d0.png">


### What does this PR do, or why is it needed?

This removes "NewSpring" from all the content categories in the app.

### How do I test this PR?

- Check home feed
- Check discover tab
- Check action list in the For You section

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._