### PR TITLE
[DEV-4003] Directs Serving Link to /serving on website

### DIFF
--- a/packages/newspringchurchapp/src/tabs/connect/ActionTable/index.js
+++ b/packages/newspringchurchapp/src/tabs/connect/ActionTable/index.js
@@ -40,7 +40,7 @@ const ActionTable = ({ token, isGroupLeader }) => (
           <Touchable
             onPress={() =>
               openUserWebView({
-                url: 'https://rock.newspring.cc/Workflows/431',
+                url: 'https://newspring.cc/serving',
               })
             }
           >


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

The previous link from 'Click here to find a serving opportunity' linked out to a connect class interest form. This wasn't bad, but could be confusing. This updates that link to link to the /serving page of the website, which explores the different areas that someone could serve in and allows them to fill out interest forms for the different areas.

### How do I test this PR?

Fire up a sim and test out the link!

## TODO

- [ ] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android if applicable
- [ ] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
