### PR TITLE
(DEV-4117) Prayer submission UI stays anonymous

### DIFF
--- a/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/AddPrayerFormConnected.js
+++ b/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/AddPrayerFormConnected.js
@@ -44,9 +44,8 @@ class AddPrayerFormConnected extends React.Component {
                   this.props.navigation.navigate('WithYou');
                 }}
                 avatarSource={photo}
-                {...this.props}
-                onClose={() => this.props.navigation.pop()}
                 title={'Join me in praying for ...'}
+                {...this.props}
               />
             )}
           </Mutation>


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

When you add a prayer anonymously, the profile image flashes because of the `resetForm` function. It makes the user fearful that the prayer wasn't submitted anonymously. This needs to wait until the screen navigation completely transitions.

### How do I test this PR?

Add a prayer anonymously

## TODO

- [ ] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android if applicable
- [ ] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
