### PR TITLE
(DEV-4121) Adjusts Prayer Button Text

### DIFF
--- a/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/AddPrayerForm.js
+++ b/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/AddPrayerForm.js
@@ -119,7 +119,7 @@ AddPrayerForm.propTypes = {
 
 AddPrayerForm.defaultProps = {
   title: 'Ask for prayer',
-  btnLabel: 'Send prayer to community',
+  btnLabel: 'Send prayer',
 };
 
 AddPrayerForm.displayName = 'AddPrayerForm';

--- a/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/__snapshots__/AddPrayerForm.tests.js.snap
+++ b/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/__snapshots__/AddPrayerForm.tests.js.snap
@@ -535,7 +535,7 @@ exports[`The AddPrayerForm component should render 1`] = `
                     }
                   }
                 >
-                  Send prayer to community
+                  Send prayer
                 </Text>
               </View>
             </View>
@@ -1185,7 +1185,7 @@ exports[`The AddPrayerForm component should render a custom avatar 1`] = `
                     }
                   }
                 >
-                  Send prayer to community
+                  Send prayer
                 </Text>
               </View>
             </View>

--- a/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/__snapshots__/AddPrayerFormConnected.tests.js.snap
+++ b/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/__snapshots__/AddPrayerFormConnected.tests.js.snap
@@ -535,7 +535,7 @@ exports[`renders AddPrayerFormConnected 1`] = `
                     }
                   }
                 >
-                  Send prayer to community
+                  Send prayer
                 </Text>
               </View>
             </View>


### PR DESCRIPTION
## DESCRIPTION

<img width="463" alt="Screen Shot 2019-10-06 at 8 55 58 PM" src="https://user-images.githubusercontent.com/2659478/66279131-58ce9380-e87d-11e9-864c-cee5e10ba5d5.png">

<img width="463" alt="Screen Shot 2019-10-06 at 9 01 56 PM" src="https://user-images.githubusercontent.com/2659478/66279133-5b30ed80-e87d-11e9-8ffe-1662e4163b8b.png">


### What does this PR do, or why is it needed?

Makes a few areas of the prayer feature more clear

### How do I test this PR?

Go to the prayer menu and take a look at the language

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._