### PR TITLE
(DEV-4117) Adds Delay to Prayer Form Reset

### DIFF
--- a/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/AddPrayerForm.js
+++ b/packages/newspringchurchapp/src/prayer/AddPrayer/AddPrayerForm/AddPrayerForm.js
@@ -59,7 +59,8 @@ const AddPrayerForm = memo(
       initialValues={{ prayer: '', anonymous: false }}
       onSubmit={(values, { resetForm }) => {
         onSubmit(values);
-        resetForm({});
+        // this is necessary so the modal can transition completely
+        setTimeout(() => resetForm({}), 1000);
       }}
     >
       {({ handleChange, handleBlur, handleSubmit, values }) => (


### PR DESCRIPTION
## DESCRIPTION

![Kapture 2019-10-08 at 15 03 33](https://user-images.githubusercontent.com/2659478/66425097-dc52c680-e9dc-11e9-9973-bb28b93a8fac.gif)


### What does this PR do, or why is it needed?

Adds a delay to the `resetForm` so that the profile image doesn't flicker.

### How do I test this PR?

Add a prayer anonymously.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._