### PR TITLE
[DEV-4168] Fix Links

### DIFF
--- a/packages/newspringchurchapp/src/live/LiveButton.js
+++ b/packages/newspringchurchapp/src/live/LiveButton.js
@@ -31,7 +31,13 @@ const LiveNowButton = () => (
         <WebBrowserConsumer>
           {(openUrl) => (
             <TouchableScale
-              onPress={() => openUrl('https://live.newspring.cc/')}
+              onPress={() =>
+                openUrl(
+                  'https://live.newspring.cc/',
+                  {},
+                  { useRockToken: true }
+                )
+              }
             >
               <LiveCard isLoading={loading}>
                 <CardContent>

--- a/packages/newspringchurchapp/src/user-settings/index.js
+++ b/packages/newspringchurchapp/src/user-settings/index.js
@@ -88,7 +88,11 @@ class UserSettings extends PureComponent {
                       <TableView>
                         <Touchable
                           onPress={() =>
-                            openUrl('https://newspring.cc/privacy')
+                            openUrl(
+                              'https://newspring.cc/privacy',
+                              {},
+                              { useRockToken: true }
+                            )
                           }
                         >
                           <Cell>
@@ -98,7 +102,13 @@ class UserSettings extends PureComponent {
                         </Touchable>
                         <Divider />
                         <Touchable
-                          onPress={() => openUrl('https://newspring.cc/terms')}
+                          onPress={() =>
+                            openUrl(
+                              'https://newspring.cc/terms',
+                              {},
+                              { useRockToken: true }
+                            )
+                          }
                         >
                           <Cell>
                             <CellText>Terms of Use</CellText>


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR fixes some of the `openUrl` links so that they have the correct arguments. This includes a fix to the link for the live banner.

### How do I test this PR?
Open the sim while things are live. Make sure that the live banner shows up, and that when you tap on it that Church Online opens up in an in-app browser.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
