### PR TITLE
(DEV-4178) Allows URLs with One Argument

### DIFF
--- a/packages/newspringchurchapp/src/testing-control-panel/index.js
+++ b/packages/newspringchurchapp/src/testing-control-panel/index.js
@@ -31,24 +31,13 @@ export default class TestingControlPanel extends PureComponent {
         </UserWebBrowserConsumer>
         <WebBrowserConsumer>
           {(openUrl) => (
-            <>
-              <TouchableCell
-                handlePress={() =>
-                  openUrl(
-                    'https://rock.newspring.cc',
-                    {},
-                    { useRockToken: true }
-                  )
-                }
-                iconName="share"
-                cellText={`Open InAppBrowser With Rock Token`}
-              />
-              <TouchableCell
-                handlePress={() => openUrl('https://rock.newspring.cc')}
-                iconName="share"
-                cellText={`Open InAppBrowser With One Argument`}
-              />
-            </>
+            <TouchableCell
+              handlePress={() =>
+                openUrl('https://rock.newspring.cc', {}, { useRockToken: true })
+              }
+              iconName="share"
+              cellText={`Open InAppBrowser With Rock Token`}
+            />
           )}
         </WebBrowserConsumer>
         <TouchableCell

--- a/packages/newspringchurchapp/src/testing-control-panel/index.js
+++ b/packages/newspringchurchapp/src/testing-control-panel/index.js
@@ -31,13 +31,24 @@ export default class TestingControlPanel extends PureComponent {
         </UserWebBrowserConsumer>
         <WebBrowserConsumer>
           {(openUrl) => (
-            <TouchableCell
-              handlePress={() =>
-                openUrl('https://rock.newspring.cc', {}, { useRockToken: true })
-              }
-              iconName="share"
-              cellText={`Open InAppBrowser With Rock Token`}
-            />
+            <>
+              <TouchableCell
+                handlePress={() =>
+                  openUrl(
+                    'https://rock.newspring.cc',
+                    {},
+                    { useRockToken: true }
+                  )
+                }
+                iconName="share"
+                cellText={`Open InAppBrowser With Rock Token`}
+              />
+              <TouchableCell
+                handlePress={() => openUrl('https://rock.newspring.cc')}
+                iconName="share"
+                cellText={`Open InAppBrowser With One Argument`}
+              />
+            </>
           )}
         </WebBrowserConsumer>
         <TouchableCell

--- a/packages/newspringchurchapp/src/ui/WebBrowser/Browser.js
+++ b/packages/newspringchurchapp/src/ui/WebBrowser/Browser.js
@@ -42,10 +42,10 @@ const Browser = {
     }
     if (auth.useRockToken && authToken) {
       url.searchParams.append('rckipid', authToken);
-      // hide nav bar for links to newspring's site
-      if (url.toString().includes('newspring.cc'))
-        url.searchParams.append('hidenav', 'true');
     }
+    // hide nav bar for links to newspring's site
+    if (url.toString().includes('newspring.cc'))
+      url.searchParams.append('hidenav', 'true');
     try {
       if (!options.externalBrowser && (await InAppBrowser.isAvailable())) {
         InAppBrowser.open(url.toString(), {

--- a/packages/newspringchurchapp/src/ui/WebBrowser/Browser.js
+++ b/packages/newspringchurchapp/src/ui/WebBrowser/Browser.js
@@ -26,7 +26,7 @@ export const getRockAuthDetails = async () => {
 const Browser = {
   open: async (
     baseURL,
-    options,
+    options = { externalBrowser: false },
     auth = { useRockCookie: false, useRockToken: false }
   ) => {
     const url = new URL(baseURL);

--- a/packages/newspringchurchapp/src/user-settings/index.js
+++ b/packages/newspringchurchapp/src/user-settings/index.js
@@ -88,11 +88,7 @@ class UserSettings extends PureComponent {
                       <TableView>
                         <Touchable
                           onPress={() =>
-                            openUrl(
-                              'https://newspring.cc/privacy',
-                              {},
-                              { useRockToken: true }
-                            )
+                            openUrl('https://newspring.cc/privacy')
                           }
                         >
                           <Cell>
@@ -102,13 +98,7 @@ class UserSettings extends PureComponent {
                         </Touchable>
                         <Divider />
                         <Touchable
-                          onPress={() =>
-                            openUrl(
-                              'https://newspring.cc/terms',
-                              {},
-                              { useRockToken: true }
-                            )
-                          }
+                          onPress={() => openUrl('https://newspring.cc/terms')}
                         >
                           <Cell>
                             <CellText>Terms of Use</CellText>


### PR DESCRIPTION
## DESCRIPTION

![Screen Shot 2019-10-29 at 3 44 54 PM](https://user-images.githubusercontent.com/2659478/67803290-202c6f00-fa63-11e9-8be3-087ad4ff1851.png)


### What does this PR do, or why is it needed?

Just makes the code a little easier to write and keeps us closer to core, now all args in the `WebBrowser.openUrl` function aren't required.

### How do I test this PR?

Click "Privacy" link, it has one arg again.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._