### PR TITLE
(DEV-4159) Adds Custom Staff News Feature

### DIFF
--- a/packages/apollos-church-api/config.yml
+++ b/packages/apollos-church-api/config.yml
@@ -158,7 +158,7 @@ HOME_FEATURES:
   - title: FOR STAFF
     subtitle: Updates for NewSpring staff
     algorithms:
-      - type: CONTENT_CHANNEL
+      - type: STAFF_NEWS
         arguments:
           contentChannelId: 5
           limit: 3

--- a/packages/apollos-church-api/src/data/features/data-source.js
+++ b/packages/apollos-church-api/src/data/features/data-source.js
@@ -1,9 +1,15 @@
 import { Features as baseFeatures } from '@apollosproject/data-connector-rock';
 import { createGlobalId } from '@apollosproject/server-core';
 import ApollosConfig from '@apollosproject/config';
-import { get } from 'lodash';
 
 export default class Features extends baseFeatures.dataSource {
+  baseAlgorithms = this.ACTION_ALGORITHIMS;
+
+  ACTION_ALGORITHIMS = {
+    ...this.baseAlgorithms,
+    STAFF_NEWS: this.contentChannelAlgorithm.bind(this),
+  };
+
   // eslint-disable-next-line class-methods-use-this
   createNoteFeature({ placeholder, id }) {
     return {
@@ -22,16 +28,22 @@ export default class Features extends baseFeatures.dataSource {
     };
   }
 
-  // TODO come up with a better way to hide features per block
-  // currently this is only showing features if you're on staff
   async getHomeFeedFeatures() {
     const { Person, Auth } = this.context.dataSources;
     const { id } = await Auth.getCurrentPerson();
     const isStaff = await Person.isStaff(id);
-    if (!isStaff) return [];
 
+    const features = ApollosConfig.HOME_FEATURES.filter((feature) => {
+      const staffOnly = feature.algorithms.filter(
+        ({ type }) => type === 'STAFF_NEWS'
+      );
+      // if there are staff only features and I'm not on staff, filter out
+      if (staffOnly.length && !isStaff) return false;
+      // TODO filter out experimental if "experimental" header isn't present
+      return true;
+    });
     return Promise.all(
-      get(ApollosConfig, 'HOME_FEATURES', []).map((featureConfig) =>
+      features.map((featureConfig) =>
         this.createActionListFeature(featureConfig)
       )
     );


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Simply breaks out the staff feature into it's own algorithm to pave the way for dealing with other features separately.

### How do I test this PR?

Log in as a staff member and as a non-staff member. You should see the staff block on the home feed respectively.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._