### PR TITLE
(DEV-4204) Adds Extra Line to Notes

### DIFF
--- a/packages/newspringchurchapp/src/content-single/Features/SermonNotes/index.js
+++ b/packages/newspringchurchapp/src/content-single/Features/SermonNotes/index.js
@@ -49,6 +49,7 @@ const SermonNotes = ({
     speakers.forEach((speaker) => {
       msg += `${speaker}\n`;
     });
+    msg += '\n';
 
     // loop through all features and add them
     const featuresWithCallbacks = features.map((feature) => {


### PR DESCRIPTION
## DESCRIPTION

![Screen Shot 2019-11-04 at 2 31 10 PM](https://user-images.githubusercontent.com/2659478/68151487-cf5bc100-ff0f-11e9-9384-d08d333d8480.png)


### What does this PR do, or why is it needed?

This adds an extra carriage return between the header and meat of the exported notes.

*NOTE:* This will probably add an extra, extra line for sermons with communicators, that is due to another issue and will be resolved shortly.

### How do I test this PR?

Export the "Third Option" sermon notes.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._