### PR TITLE
[DEV-4239] Split Content Channel Name

### DIFF
--- a/packages/newspringchurchapp/src/content-single/WeekendContentItem/index.js
+++ b/packages/newspringchurchapp/src/content-single/WeekendContentItem/index.js
@@ -88,9 +88,7 @@ const WeekendContentItem = ({ content, loading }) => {
                             isLive={!!liveStream}
                             title={
                               content.parentChannel &&
-                              content.parentChannel.name
-                                .replace('NewSpring - ', '')
-                                .replace('Rock - ', '')
+                              content.parentChannel.name.split(' - ').pop()
                             }
                           />
                         )}

--- a/packages/newspringchurchapp/src/tabs/discover/DiscoverFeed/index.js
+++ b/packages/newspringchurchapp/src/tabs/discover/DiscoverFeed/index.js
@@ -22,7 +22,7 @@ const renderItem = (
 ) => (
   <TileContentFeed
     id={item.id}
-    name={item.name.replace('NewSpring - ', '').replace('Rock - ', '')}
+    name={item.name.split(' - ').pop()}
     content={get(item, 'childContentItemsConnection.edges', []).map(
       (edge) => edge.node
     )}

--- a/packages/newspringchurchapp/src/tabs/home/Features/index.js
+++ b/packages/newspringchurchapp/src/tabs/home/Features/index.js
@@ -104,9 +104,7 @@ const Features = memo(({ navigation }) => (
                 actions={actions.map((action) => ({
                   ...action,
                   subtitle: action.subtitle
-                    ? action.subtitle
-                        .replace('NewSpring - ', '')
-                        .replace('Rock - ', '')
+                    ? action.subtitle.split(' - ').pop()
                     : '',
                 }))}
                 onPressActionItem={({ action, relatedNode }) => {

--- a/packages/newspringchurchapp/src/ui/ContentCardConnected/ContentCardConnected.js
+++ b/packages/newspringchurchapp/src/ui/ContentCardConnected/ContentCardConnected.js
@@ -31,13 +31,7 @@ const ContentCardConnected = memo(
                   {...node}
                   hasAction={hasMedia}
                   isLive={isLive}
-                  labelText={
-                    isLive
-                      ? 'Live'
-                      : labelText
-                          .replace('NewSpring - ', '')
-                          .replace('Rock - ', '')
-                  }
+                  labelText={isLive ? 'Live' : labelText.split(' - ').pop()}
                   {...otherProps}
                   coverImage={coverImage}
                   isLoading={loading}


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR splits the channel name on the " - ".

*Please Note*: I was going to make this change on the API, but decided against it. Mostly because I didn't see the need to have to override the content channel API (which we're not doing yet) just to fix the name of the parent channel when I could continue to fix it where we had been fixing it. 

### How do I test this PR?
Look at the places where we show the content channel name and make sure they show correctly. In particular look at:
* Home feed campaign item, features, and content cards
* Discover feed section titles and cards
* Individual sermons.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
