### PR TITLE
[DEV-4241] Home Feed Feature Updates

### DIFF
--- a/packages/apollos-church-api/config.yml
+++ b/packages/apollos-church-api/config.yml
@@ -155,19 +155,20 @@ HOME_FEATURES:
   #- title: FOR YOU
   #algorithms: [PERSONA_FEED]
   #subtitle: Explore what God calls you to today
-  #- title: BULLETIN
-  #subtitle: What's happening at Newspring?
-  #algorithms:
-  #- type: CONTENT_CHANNEL
-  #arguments:
-  #contentChannelId: 27
   #- type: UPCOMING_EVENTS
-  - title: FOR STAFF
+  - title:
     subtitle: Updates for NewSpring staff
     algorithms:
       - type: STAFF_NEWS
         arguments:
           contentChannelId: 513
+          limit: 3
+  - title:
+    subtitle: Next steps
+    algorithms:
+      - type: CONTENT_CHANNEL
+        arguments:
+          contentChannelId: 459
           limit: 3
 
 # Default mapping of field types -> ids. There's probably no reason to edit this.

--- a/packages/apollos-church-api/config.yml
+++ b/packages/apollos-church-api/config.yml
@@ -156,15 +156,13 @@ HOME_FEATURES:
   #algorithms: [PERSONA_FEED]
   #subtitle: Explore what God calls you to today
   #- type: UPCOMING_EVENTS
-  - title:
-    subtitle: Updates for NewSpring staff
+  - subtitle: Updates for NewSpring staff
     algorithms:
       - type: STAFF_NEWS
         arguments:
           contentChannelId: 513
           limit: 3
-  - title:
-    subtitle: Next steps
+  - subtitle: Next steps
     algorithms:
       - type: CONTENT_CHANNEL
         arguments:

--- a/packages/newspringchurchapp/src/tabs/home/Features/getFeedFeatures.js
+++ b/packages/newspringchurchapp/src/tabs/home/Features/getFeedFeatures.js
@@ -10,7 +10,6 @@ export default gql`
         actions {
           id
           title
-          subtitle
           action
           image {
             sources {

--- a/packages/newspringchurchapp/src/tabs/home/Features/index.js
+++ b/packages/newspringchurchapp/src/tabs/home/Features/index.js
@@ -101,10 +101,7 @@ const Features = memo(({ navigation }) => (
                     <H3 numberOfLines={3}>{subtitle}</H3>
                   </>
                 }
-                actions={actions.map((action) => ({
-                  ...action,
-                  subtitle: '',
-                }))}
+                actions={actions}
                 onPressActionItem={({ action, relatedNode }) => {
                   if (action === 'READ_CONTENT') {
                     navigation.navigate('ContentSingle', {

--- a/packages/newspringchurchapp/src/tabs/home/Features/index.js
+++ b/packages/newspringchurchapp/src/tabs/home/Features/index.js
@@ -103,9 +103,7 @@ const Features = memo(({ navigation }) => (
                 }
                 actions={actions.map((action) => ({
                   ...action,
-                  subtitle: action.subtitle
-                    ? action.subtitle.split(' - ').pop()
-                    : '',
+                  subtitle: '',
                 }))}
                 onPressActionItem={({ action, relatedNode }) => {
                   if (action === 'READ_CONTENT') {


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR:
* Adds the "Next Steps" feature (pulls from the `App-Bulletin` channel) to the home feed.
* Removes the titles for "Bulletin" and "For Staff" from the features.
* Removes the content channel name from the home feed features.

### How do I test this PR?
Open up the home feed and make sure that you see the "Next Steps" feature.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
