### PR TITLE
chore: Removed Pills from Horizontal Content Cards

### DIFF
--- a/packages/newspringchurchapp/src/ui/HorizontalContentCardConnected/horizontalContentCardComponentMapper.js
+++ b/packages/newspringchurchapp/src/ui/HorizontalContentCardConnected/horizontalContentCardComponentMapper.js
@@ -49,9 +49,15 @@ const horizontalContentCardComponentMapper = ({
 
   switch (typename) {
     case 'ContentSeriesContentItem':
-      return <HorizontalHighlightCard {...props} />;
+      return <HorizontalHighlightCard {...props} labelText={null} />;
     case 'MediaContentItem':
-      return <HorizontalHighlightCard title={hyphenatedTitle} {...props} />;
+      return (
+        <HorizontalHighlightCard
+          title={hyphenatedTitle}
+          {...props}
+          labelText={null}
+        />
+      );
     case 'WeekendContentItem':
       return (
         <StyledHorizontalHightlightCard


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR removes the pills from the horizontal content cards

![Screenshot 2019-11-20 22 14 56](https://user-images.githubusercontent.com/3229463/69301293-be839e80-0be3-11ea-8648-88cb286532ca.png)

### How do I test this PR?
Make sure all the pills are off the horizontal content cards on the discover feed, but they still show on the cards on the home feed and on the horizontal cards for devos and sermons.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
