### PR TITLE
chore: Updated Give Link

### DIFF
--- a/packages/newspringchurchapp/src/tabs/connect/ActionBar.js
+++ b/packages/newspringchurchapp/src/tabs/connect/ActionBar.js
@@ -12,7 +12,7 @@ const Toolbar = ({ navigation }) => (
         <ActionBarItem
           onPress={() =>
             openUrl(
-              'https://newspring.cc/give/now1',
+              'https://newspring.cc/give/now',
               { externalBrowser: true },
               { useRockToken: true }
             )


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR updates the "Give" link to be it's final form.

### How do I test this PR?
Just check out the code and make sure that the link says that it is going to `https://newspring.cc/give/now`. It will take you to a 404 page if you tap on it in the app. This is due to a limitation in the redirector logic in Rock. It has been decided that we are okay with it not working until we move the new giving page to its final destination at `/give/now`. 

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
