### PR TITLE
chore: Removes Development Error Logging

### DIFF
--- a/packages/newspringchurchapp/src/bugsnag.js
+++ b/packages/newspringchurchapp/src/bugsnag.js
@@ -5,6 +5,7 @@ import { onError } from 'apollo-link-error';
 const configuration = new Configuration();
 configuration.apiKey = Config.BUGSNAG_API_KEY;
 configuration.releaseStage = Config.BUGSNAG_STAGE;
+configuration.notifyReleaseStages = ['production', 'staging'];
 const bugsnag = new Client(configuration);
 
 const bugsnagLink = onError(({ graphQLErrors, networkError, operation }) => {


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Turns off error logging for the developmement stage so we don't see a bunch of invalid errors.

### How do I test this PR?

## TODO

- [ ] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android if applicable
- [ ] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._